### PR TITLE
 Add --format to be able to select between PNG and SVG output

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,8 +22,11 @@ module.exports = function (grunt) {
     },
 
     shell: {
-      create: {
+      createPNG: {
         command: 'node ./bin/nomnoml -i ./test/piracy.nomnoml -o ./test/piracy.png'
+      },
+      createSVG: {
+        command: 'node ./bin/nomnoml -i ./test/piracy.nomnoml -o ./test/piracy.svg -f svg'
       }
     },
 

--- a/bin/nomnoml
+++ b/bin/nomnoml
@@ -8,11 +8,12 @@ commander.version('0.2.2')
     .usage('[option]')
     .option('-i, --input <path>', 'file with nomnoml source to read from')
     .option('-o, --output <path>', 'file for the image output to write to')
+    .option('-f, --format <format>', 'output format (png or svg)')
     .option('-w, --width <pixels>', 'width of the canvas to draw on', parseInt)
     .option('-h, --height <pixels>', 'height of the canvas to draw on', parseInt);
 
 commander.on('--help', function () {
-  console.log('  The output format is PNG.  The default canvas size is 640x480 pixels.');
+  console.log('  The default output format is PNG.  The default canvas size is 640x480 pixels.');
   console.log('  If the input file is omitted, the source is read from the standard input.');
   console.log('  If the output file is omitted, the image is written to the standard output.');
   console.log();
@@ -26,6 +27,7 @@ commander.parse(process.argv);
 
 var options = {
   output: commander.output || process.stdout,
+  format: commander.format,
   width: commander.width,
   height: commander.height
 };

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -1,7 +1,8 @@
 var Canvas = require('canvas'),
     fs = require('fs'),
     nomnoml = require('nomnoml'),
-    Q = require('q');
+    Q = require('q'),
+    stream = require('stream');
 
 module.exports = function (options) {
   return Q.Promise(function (resolve, reject) {
@@ -11,37 +12,69 @@ module.exports = function (options) {
     function processInputText() {
       var width = options.width || 640,
           height = options.height || 480,
-          canvas = new Canvas(width, height),
+          format = options.format ? options.format.toLowerCase() : 'png',
+          canvas = new Canvas(width, height, format),
           pngStream, outputStream;
 
       nomnoml.draw(canvas, inputText);
 
-      if (options.output) {
-        pngStream = canvas.pngStream();
-        pngStream.on('error', function (error) {
-          reject(error);
-        });
-
-        if (typeof options.output === 'string') {
-          outputStream = fs.createWriteStream(options.output);
-        } else {
-          outputStream = options.output;
-        }
-        outputStream.on('error', function (error) {
-          reject(error);
-        });
-
-        pngStream
-          .pipe(outputStream)
-          .on('finish', function () {
-            resolve();
-          })
-          .on('error', function (error) {
+      if (format === 'png') {
+        if (options.output) {
+          pngStream = canvas.pngStream();
+          pngStream.on('error', function (error) {
             reject(error);
           });
-      } else {
-        resolve(options.resultType === 'stream' ?
-          canvas.pngStream() : canvas.toBuffer());
+
+          if (typeof options.output === 'string') {
+            outputStream = fs.createWriteStream(options.output);
+          } else {
+            outputStream = options.output;
+          }
+          outputStream.on('error', function (error) {
+            reject(error);
+          });
+
+          pngStream
+            .pipe(outputStream)
+            .on('finish', function () {
+              resolve();
+            })
+            .on('error', function (error) {
+              reject(error);
+            });
+        } else {
+          resolve(options.resultType === 'stream' ?
+            canvas.pngStream() : canvas.toBuffer());
+        }
+      }
+      else if (format === 'svg') {
+        var buffer = canvas.toBuffer();
+        if (options.output) {
+          if (typeof options.output === 'string') {
+            outputStream = fs.createWriteStream(options.output);
+          } else {
+            outputStream = new stream.PassThrough();
+            outputStream.pipe(options.output);
+          }
+          outputStream
+            .on('finish', function () {
+              resolve();
+            })
+            .on('error', function (error) {
+              reject(error);
+            })
+            .end(buffer);
+        }
+        else {
+          if (options.resultType === 'stream') {
+            var bufferStream = new stream.PassThrough();
+            bufferStream.end(buffer);
+            resolve(bufferStream);
+          }
+          else {
+            resolve(buffer);
+          }
+        }
       }
     }
 

--- a/test/generate_test.js
+++ b/test/generate_test.js
@@ -126,7 +126,7 @@ exports.when = {
       });
   },
 
-  'called with correct input and ouptut file names': function (test) {
+  'called with correct input and output file names': function (test) {
     var name = path.join(__dirname, 'piracy'),
         promise = generateDiagram({
           inputFile: name + '.nomnoml',

--- a/test/generate_test.js
+++ b/test/generate_test.js
@@ -16,6 +16,14 @@ exports.when = {
     test.done();
   },
 
+  'called on the command line with format=svg': function (test) {
+    var name = path.join(__dirname, 'piracy'),
+        output = fs.statSync(name + '.svg');
+    test.ok(output.isFile() && output.size > 0, 'creates a SVG file');
+    fs.unlinkSync(name + '.svg');
+    test.done();
+  },
+
   'required': function (test) {
     test.equal('function', typeof generateDiagram, 'returns a generator function');
     test.done();
@@ -126,6 +134,27 @@ exports.when = {
       });
   },
 
+  'called with input and output streams, with format=svg': function (test) {
+    var name = path.join(__dirname, 'piracy'),
+        promise = generateDiagram({
+          input: fs.createReadStream(name + '.nomnoml'),
+          format: 'svg',
+          output: fs.createWriteStream(name + '.svg')
+        });
+    promise
+      .then(function (result) {
+        var output = fs.statSync(name + '.svg');
+        test.ok(true, 'succeeds');
+        test.ok(output.isFile() && output.size > 0, 'creates a SVG file');
+        fs.unlinkSync(name + '.svg');
+        test.done();
+      })
+      .catch(function (error) {
+        test.ok(false, error);
+        test.done();
+      });
+  },
+
   'called with correct input and output file names': function (test) {
     var name = path.join(__dirname, 'piracy'),
         promise = generateDiagram({
@@ -138,6 +167,27 @@ exports.when = {
         test.ok(true, 'succeeds');
         test.ok(output.isFile() && output.size > 0, 'creates a PNG file');
         fs.unlinkSync(name + '.png');
+        test.done();
+      })
+      .catch(function (error) {
+        test.ok(false, error);
+        test.done();
+      });
+  },
+
+  'called with correct input and output file names, with format=svg': function (test) {
+    var name = path.join(__dirname, 'piracy'),
+        promise = generateDiagram({
+          inputFile: name + '.nomnoml',
+          format: 'svg',
+          output: name + '.svg'
+        });
+    promise
+      .then(function (result) {
+        var output = fs.statSync(name + '.svg');
+        test.ok(true, 'succeeds');
+        test.ok(output.isFile() && output.size > 0, 'creates a SVG file');
+        fs.unlinkSync(name + '.svg');
         test.done();
       })
       .catch(function (error) {


### PR DESCRIPTION
The Cairo-based `node-canvas` can export its contents to SVG: adding a `--format` parameter gives me the ability to use that to get a SVG from the command line.