### PR TITLE
Update dependency to reference upstream library

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "canvas": "~1.6.5",
     "commander": "~2.9.0",
-    "nomnoml": "git://github.com/prantlf/nomnoml.git#combined",
+    "nomnoml": "0.1.1",
     "q": "~2.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "canvas": "~1.6.5",
     "commander": "~2.9.0",
-    "nomnoml": "0.1.1",
+    "nomnoml": "~0.1.1",
     "q": "~2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
The [upstream library](https://github.com/skanaar/nomnoml) has published to [npm](https://www.npmjs.com/package/nomnoml) since https://github.com/prantlf/nomnoml was forked. 

Thought it would be nice to track the main library. If you'd prefer to depend on your fork instead, feel free to close.

Thanks for the cli, btw! Exactly what I was looking for!